### PR TITLE
Ensure owner

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,25 +1,28 @@
 ---
 
 - name: Install package dependencies
-  package:
+  ansible.builtin.package:
     name: "{{ item }}"
     state: present
     update_cache: yes
   with_items: "{{ azcopy_pkg_deps }}"
 
 - name: Check current version installed
-  shell: "{{ azcopy_bin_path }}/azcopy --version 2>&1 | head -n 1 | grep {{ azcopy_version }}"
+  ansible.builtin.shell: "{{ azcopy_bin_path }}/azcopy --version 2>&1 | head -n 1 | grep {{ azcopy_version }}"
   failed_when: false
   changed_when: false
   register: version
 
 - name: "Install azcopy {{ azcopy_version }}"
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ azcopy_pkg_url }}"
     dest: "{{ azcopy_bin_path }}"
+    owner: "root"
+    group: "root"
+    mode: "u+rwx,g+rx,o+rx"
     remote_src: yes
     exclude:
       - ThirdPartyNotice.txt
       - NOTICE.txt
-    extra_opts: [--strip-components=1]
+    extra_opts: [--strip-components=1, "azcopy_linux_amd64_{{ azcopy_version }}/azcopy"]
   when: version.rc != 0


### PR DESCRIPTION
Because :

```
If mode is not specified and the destination file does not exist, the default umask on the system will be used when setting the mode for the newly created file.
If mode is not specified and the destination file does exist, the mode of the existing file will be used. Specifying mode is the best way to ensure files are created with the correct permissions.
See CVE-2020-1736 for further details.
```
Also I hardcode `amd64` perhaps we should built the URL with $arch and $version variables and use the $arch in the archive name too

Also not sure we really need this part "azcopy_linux_amd64_{{ azcopy_version }}/azcopy" but sometimes during my tests the perms was changed on /usr/local/bin without understanding why